### PR TITLE
Add grid at final step and original prompt to grid exif

### DIFF
--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -64,13 +64,13 @@ class Script(scripts.Script):
             output_images += proc.images
             # TODO: Also add wildcard data to exif of individual images, currently only appear on the saved grid.
             infotext = "Wildcard prompt: "+original_prompt+"\nExample: "+proc.info
-            all_seeds.append(p.seed)
+            all_seeds.append(proc.seed)
             infotexts.append(infotext)
             if initial_seed is None:
                 initial_info = infotext
-                initial_seed = p.seed
+                initial_seed = proc.seed
             if not same_seed:
-                p.seed += 1
+                p.seed = proc.seed+1
 
         p.do_not_save_grid = original_do_not_save_grid
 
@@ -80,6 +80,7 @@ class Script(scripts.Script):
 
             if opts.return_grid:
                 infotexts.insert(0, initial_info)
+                all_seeds.insert(0, initial_seed)
                 output_images.insert(0, grid)
 
             if opts.grid_save:

--- a/scripts/wildcards.py
+++ b/scripts/wildcards.py
@@ -5,6 +5,7 @@ import traceback
 import random
 
 import modules.scripts as scripts
+import modules.images as images
 import gradio as gr
 
 from modules.processing import Processed, process_images
@@ -34,20 +35,54 @@ class Script(scripts.Script):
         original_prompt = p.prompt[0] if type(p.prompt) == list else p.prompt
         all_prompts = ["".join(replace_wildcard(chunk) for chunk in original_prompt.split("__")) for _ in range(p.batch_size * p.n_iter)]
 
-        print(f"Will process {p.batch_size * p.n_iter} images in {p.n_iter} batches.")
+        # TODO: Pregenerate seeds to prevent overlaps when batch_size is > 1
+        # Known issue: Clicking "recycle seed" on an image in a batch_size > 1 may not get the correct seed.
+        # (unclear if this is an issue with this script or not, but pregenerating would prevent). However,
+        # filename and exif data on individual images match correct seeds (testable via sending png info to txt2img).
+        all_seeds = []
+        infotexts = []
 
-        p.do_not_save_grid = True
+        initial_seed = None
+        initial_info = None
+
+        print(f"Will process {p.batch_size * p.n_iter} images in {p.n_iter} batches.")
 
         state.job_count = p.n_iter
         p.n_iter = 1
 
-        images = []
+        original_do_not_save_grid = p.do_not_save_grid
+
+        p.do_not_save_grid = True
+
+        output_images = []
         for batch_no in range(state.job_count):
             state.job = f"{batch_no+1} out of {state.job_count}"
             p.prompt = all_prompts[batch_no*p.batch_size:(batch_no+1)*p.batch_size]
+            if cmd_opts.enable_console_prompts:
+                print(f"wildcards.py: {p.prompt}")
             proc = process_images(p)
-            images += proc.images
+            output_images += proc.images
+            # TODO: Also add wildcard data to exif of individual images, currently only appear on the saved grid.
+            infotext = "Wildcard prompt: "+original_prompt+"\nExample: "+proc.info
+            all_seeds.append(p.seed)
+            infotexts.append(infotext)
+            if initial_seed is None:
+                initial_info = infotext
+                initial_seed = p.seed
             if not same_seed:
                 p.seed += 1
 
-        return Processed(p, images, p.seed, "")
+        p.do_not_save_grid = original_do_not_save_grid
+
+        unwanted_grid_because_of_img_count = len(output_images) < 2 and opts.grid_only_if_multiple
+        if (opts.return_grid or opts.grid_save) and not p.do_not_save_grid and not unwanted_grid_because_of_img_count:
+            grid = images.image_grid(output_images, p.batch_size)
+
+            if opts.return_grid:
+                infotexts.insert(0, initial_info)
+                output_images.insert(0, grid)
+
+            if opts.grid_save:
+                images.save_image(grid, p.outpath_grids, "grid", all_seeds[0], original_prompt, opts.grid_format, info=initial_info, short_filename=not opts.grid_extended_filename, p=p, grid=True)
+
+        return Processed(p, output_images, initial_seed, initial_info, all_prompts=all_prompts, all_seeds=all_seeds, infotexts=infotexts, index_of_first_image=0)


### PR DESCRIPTION
This PR does the following:

- adds automatic grid creation at the end of a batch of wildcards
- works for for all batch sizes and batch counts (as far as I can tell)
- adds exif data to grid images, including original wildcard prompt (+ 1st generated prompt as an example)
- maintains existing exif on all individually generated images

Additional stuff I spotted that could use another pair of eyes:

- Sanity check which should be proc.seed vs p.seed on lines 67-71
- Pregenerate seeds to prevent overlaps when batch_size is > 1
- Also add wildcard data to exif of individual images, currently only appear on the saved grid.

Known issue:

- Clicking "recycle seed" on an image in a batch_size > 1 may not get the correct seed. It's unclear if this is an issue with this script or not, but pregenerating would prevent race conditions in `p.seed+=1` incrementing. Filename and exif data on individual images match correct seeds (testable via sending png info to txt2img) in all batch size/count combinations.